### PR TITLE
asocket: added error check in asocket_con_rcv

### DIFF
--- a/asocket/src/asocket_trx.c
+++ b/asocket/src/asocket_trx.c
@@ -199,7 +199,12 @@ int asocket_con_rcv(struct asocket_con* sk_con, struct skcmd **rx_msg)
 //    fprintf(stderr, "waiting\n");
 
     while(1){
-        rx_len += recv(sk_con->fd, rx_buf+rx_len, (SOCKET_TC_BUF_LEN-1)-rx_len, 0);
+        retval = recv(sk_con->fd, rx_buf+rx_len, (SOCKET_TC_BUF_LEN-1)-rx_len, 0);
+
+	if(retval < 0)
+		goto out;
+
+	rx_len += retval;
     
         rx_buf[rx_len] = '\0';
 


### PR DESCRIPTION
In some rare cases recv returns -1,
without this patch this results in "\0" being written in rx_buf[-1].