### PR TITLE
db-module: refactoring and prevent database lockup

### DIFF
--- a/logdb/src/logdb.c
+++ b/logdb/src/logdb.c
@@ -344,12 +344,18 @@ void logdb_close(struct logdb *db) {
 
 /* Add event */
 int logdb_evt_add(struct logdb *db, int eid, time_t time, const char* value) {
+	int retval;
 	char sql[DB_QUERY_MAX];
 
 	snprintf(sql, DB_QUERY_MAX, "UPDATE %s SET lastlog=%ld WHERE rowid=%d",
 			DB_TABLE_NAME_EVENT_TYPE, time, eid);
 
-	logdb_sql(db, sql, NULL );
+	retval = logdb_sql(db, sql, NULL);
+	if (retval < 0) {
+		PRINT_ERR("ERROR updating table %s", DB_TABLE_NAME_EVENT_TYPE);
+		return retval;
+	}
+
 
 	snprintf(sql, DB_QUERY_MAX, "INSERT INTO %s (eid, time, value) "
 		"VALUES ('%d', '%ld' , '%s')", DB_TABLE_NAME_EVENT_LOG, eid, time,


### PR DESCRIPTION
The logdb_etype_get_eid sometimes fails if rpclient is accessing the db
simultaneously, this causes the db-module loop(module_write_log) to lock it self
in the while loop forever.
The Watchdog have catched this in the past, in my system the error have been
happening every 5 - 6 days.
Contdaem have now run for +30 days without any problems.